### PR TITLE
Support dataset auto translation

### DIFF
--- a/ckanext/dcat/harvesters/rdf.py
+++ b/ckanext/dcat/harvesters/rdf.py
@@ -233,6 +233,14 @@ class DCATRDFHarvester(DCATHarvester):
                         if source_dataset.owner_org:
                             dataset['owner_org'] = source_dataset.owner_org
 
+                    # Initialize translator
+                    if harvest_job.translate_lang:
+                        log.debug('DCAT/RDF translation language = {0}'.format(harvest_job.translate_lang))
+                        self.init_translate(harvest_job.translate_lang)
+
+                        # translate dataset content (with tags and groups)
+                        self.translate_pakage(dataset)
+
                     # Try to get a unique identifier for the harvested dataset
                     guid = self._get_guid(dataset, source_url=source_dataset.url)
 


### PR DESCRIPTION
This feature depends on https://github.com/wanam/ckanext-harvest/commit/e6eb6acab777892cab6d43ad94db4d1edc3efe1b, check https://github.com/MobiDataLab/ckanext-harvest/pull/1.

It uses Google Translate free plan through deep-translator library: https://github.com/nidhaloff/deep-translator

Translation can be triggered during harvesting with "-t/--translate language" argument, where language code is ISO 639-1 which is the alpha-2 code.

Example:
ckan --config=/etc/ckan/default/ckan.ini harvester gather-consumer -t fr